### PR TITLE
Root actions

### DIFF
--- a/index.ls
+++ b/index.ls
@@ -8,6 +8,8 @@ export class Controller
 
 	@method = (method, action)-->
 		action import {method}
+	
+	@root = (import {+root})
 
 	for m in <[get post put delete patch options head trace connect]>
 		@[m] = @method m

--- a/index.ls
+++ b/index.ls
@@ -5,7 +5,6 @@ require! {
 
 flat-map = (xs, f)-->
 	xs.reduce ((a, x)-> a ++ f x), []
-obj = -> [[k, v] for k, v of it]
 guard = (cond)-> if cond then [null] else []
 
 export class Controller
@@ -20,15 +19,15 @@ export class Controller
 		@[m] = @method m
 
 	@routes = ->
-		[action, fn] <~ flat-map obj @::
+		action <~ flat-map Object.keys @::
 		<~ flat-map guard action not of Controller::
 
-		params = get-parameter-names fn
-		handler = @handle action, fn, params
+		params = get-parameter-names @::[action]
+		handler = @handle action, params
 
-		path <- flat-map @make-paths action, params
+		path <~ flat-map @make-paths action, params
 		respond do
-			fn.method ? \get
+			@::[action].method ? \get
 			path
 			handler
 
@@ -37,7 +36,7 @@ export class Controller
 		
 		["/#{@display-name.to-lower-case!}/#action/#params-path"]
 
-	@handle = (action, fn, params)-> (req)~>
+	@handle = (action, params)-> (req)~>
 		values = [req.params[k] for k in params]
 		controller = new this req
 		controller[action] ...values

--- a/index.ls
+++ b/index.ls
@@ -1,6 +1,7 @@
 require! {
-	\get-parameter-names
+	'get-parameter-names'
 	'livewire/lib/respond'
+	path.normalize
 }
 
 flat-map = (xs, f)-->
@@ -32,9 +33,14 @@ export class Controller
 			handler
 
 	@make-paths = (action, params)->
-		params-path = params.map (':' ++) .join '/'
-		
-		["/#{@display-name.to-lower-case!}/#action/#params-path"]
+		params-parts = params.map (':' +)
+		make-path = normalize . ('/' +) . (.join '/')
+		classname = @display-name.to-lower-case!
+
+		[
+			[classname, action]
+			[classname] if @::[action].root
+		].filter (?) .map make-path . (++ params-parts)
 
 	@handle = (action, params)-> (req)~>
 		values = [req.params[k] for k in params]

--- a/test.ls
+++ b/test.ls
@@ -24,8 +24,6 @@ export "Sodor Controller":
 			o = {}
 			Controller.root o
 			expect o .to.have.property \root true
-	
-	
 
 	"make-paths":
 		"should return a path based on classname and action name": ->
@@ -76,7 +74,7 @@ export "Sodor Controller":
 					expect b .to.be \world
 					done!
 
-			o = Foo.handle \bar Foo::bar, [\a \b]
+			o = Foo.handle \bar [\a \b]
 			o params:
 				a: \hello
 				b: \world
@@ -99,9 +97,9 @@ export "Sodor Controller":
 				c: ->
 
 			Foo.routes!
-			expect Controller.handle .to.be.called-with \a Foo::a
-			expect Controller.handle .to.be.called-with \b Foo::b
-			expect Controller.handle .to.be.called-with \c Foo::c
+			expect Controller.handle .to.be.called-with \a
+			expect Controller.handle .to.be.called-with \b
+			expect Controller.handle .to.be.called-with \c
 
 		"should make routes for each handler": ->
 			Controller.handle.returns handler = ->

--- a/test.ls
+++ b/test.ls
@@ -19,6 +19,12 @@ export "Sodor Controller":
 				expect o .to.have.property \method m
 		] for m in <[get post put delete patch options head trace connect]>}
 
+	"root":
+		"should set root to be true": ->
+			o = {}
+			Controller.root o
+			expect o .to.have.property \root true
+
 	"make-handler":
 		"should return a path based on classname and action name": ->
 			class Foo extends Controller

--- a/test.ls
+++ b/test.ls
@@ -28,17 +28,20 @@ export "Sodor Controller":
 	"make-paths":
 		"should return a path based on classname and action name": ->
 			class Foo extends Controller
+				bar: ->
 			o = Foo.make-paths \bar []
-			expect o .to.contain "/foo/bar/"
+			expect o .to.contain "/foo/bar"
 
 		"should add path parts based on function params":
 			"with a single parameter": ->
 				class Foo extends Controller
+					bar: ->
 				o = Foo.make-paths \bar [\a]
 				expect o .to.contain "/foo/bar/:a"
 
 			"with multiple parameters": ->
 				class Foo extends Controller
+					bar: ->
 				o = Foo.make-paths \bar <[a b c d]>
 				expect o .to.contain "/foo/bar/:a/:b/:c/:d"
 

--- a/test.ls
+++ b/test.ls
@@ -24,102 +24,107 @@ export "Sodor Controller":
 			o = {}
 			Controller.root o
 			expect o .to.have.property \root true
+	
+	
 
-	"make-handler":
+	"make-paths":
 		"should return a path based on classname and action name": ->
 			class Foo extends Controller
-			o = Foo.make-handler \bar ->
-			expect o.path .to.be "/foo/bar/"
+			o = Foo.make-paths \bar []
+			expect o .to.contain "/foo/bar/"
 
 		"should add path parts based on function params":
 			"with a single parameter": ->
 				class Foo extends Controller
-				o = Foo.make-handler \bar (a)->
-				expect o.path .to.be "/foo/bar/:a"
+				o = Foo.make-paths \bar [\a]
+				expect o .to.contain "/foo/bar/:a"
 
 			"with multiple parameters": ->
 				class Foo extends Controller
-				o = Foo.make-handler \bar (a,b,c,d)->
-				expect o.path .to.be "/foo/bar/:a/:b/:c/:d"
+				o = Foo.make-paths \bar <[a b c d]>
+				expect o .to.contain "/foo/bar/:a/:b/:c/:d"
 
-			"even with a method decorator": ->
-				class Foo extends Controller
-				o = Foo.make-handler \bar Foo.post (a)->
-				expect o.path .to.be "/foo/bar/:a"
+	"handle":
+		"should instantiate the controller": (done)->
+			c = expect.sinon.spy!
+			class Foo extends Controller
+				constructor$$: c
+				bar: ->
+					expect this .to.be.a Foo
+					expect c .to.be.called!
+					done!
 
-		"should wrap actions in handlers":
-			"that instantiate the controller": (done)->
-				c = expect.sinon.spy!
-				class Foo extends Controller
-					constructor$$: c
-					bar: ->
-						expect this .to.be.a Foo
-						expect c .to.be.called!
-						done!
+			(Foo.handle \bar Foo::bar, [])!
 
-				o = Foo.make-handler \bar Foo::bar
-				o.handler!
+		"should pass through return values": ->
+			class Foo extends Controller
+				bar: -> \world
 
-			"that pass through return values": ->
-				class Foo extends Controller
-					bar: -> \world
+			o = Foo.handle \bar Foo::bar, []
+			expect o! .to.be \world
 
-				o = Foo.make-handler \bar Foo::bar
-				expect o.handler! .to.be \world
+		"should send url parameters to the right places": (done)->
+			class Foo extends Controller
+				bar: (a,b)->
+					expect a .to.be \hello
+					expect b .to.be \world
+					done!
 
-			"that send url parameters to the right places": (done)->
-				class Foo extends Controller
-					bar: (a,b)->
-						expect a .to.be \hello
-						expect b .to.be \world
-						done!
-
-				o = Foo.make-handler \bar Foo::bar
-				o.handler params:
-					a: \hello
-					b: \world
+			o = Foo.handle \bar Foo::bar, [\a \b]
+			o params:
+				a: \hello
+				b: \world
 
 	"routes":
 		before: ->
 			@respond = expect.sinon.stub!
 			sodor.__set__ {@respond}
+			expect.sinon.stub Controller, \handle
+			expect.sinon.stub Controller, \makePaths
 
 		before-each: ->
-			expect.sinon.stub Controller, \makeHandler
-
-		after-each: ->
-			Controller.make-handler.restore!
+			Controller.make-paths.returns ['/']
+			Controller.handle.returns ->
 
 		"should make handlers for each action": ->
-			Controller.make-handler.returns path:'' handler:->
-
 			class Foo extends Controller
 				a: ->
 				b: ->
 				c: ->
 
 			Foo.routes!
-			expect Controller.make-handler .to.be.called-with \a Foo::a
-			expect Controller.make-handler .to.be.called-with \b Foo::b
-			expect Controller.make-handler .to.be.called-with \c Foo::c
+			expect Controller.handle .to.be.called-with \a Foo::a
+			expect Controller.handle .to.be.called-with \b Foo::b
+			expect Controller.handle .to.be.called-with \c Foo::c
 
 		"should make routes for each handler": ->
-			path = '/'
-			handler = ->
-			Controller.make-handler.returns {path, handler}
-
+			Controller.handle.returns handler = ->
 			class Foo extends Controller
 				a: ->
 
 			Foo.routes!
-			expect @respond .to.be.called-with \get path, handler
+			expect @respond .to.be.called-with \get '/' handler
 			
 		"should pass through the method": ->
-			Controller.make-handler.returns path: '' handler: ->
-
 			class Foo extends Controller
 				a: @post ->
 
 			Foo.routes!
 			expect @respond .to.be.called-with \post
+
+		"should create multiple routes for multiple paths": ->
+			Controller.make-paths.returns [\a \b]
+			class Foo extends Controller
+				a: ->
+
+			Foo.routes!
+			expect @respond .to.be.called-with \get 'a'
+			expect @respond .to.be.called-with \get 'b'
+
+		"should return the list of routes": ->
+			@respond.returns \a
+			class Foo extends Controller
+				a: ->
+
+			expect Foo.routes! .to.contain \a
 

--- a/test.ls
+++ b/test.ls
@@ -44,6 +44,12 @@ export "Sodor Controller":
 				o = Foo.make-paths \bar <[a b c d]>
 				expect o .to.contain "/foo/bar/:a/:b/:c/:d"
 
+		"should create root paths for a root-annotated action": ->
+			class Foo extends Controller
+				bar: @root ->
+
+			expect Foo.make-paths \bar [] .to.contain '/foo'
+
 	"handle":
 		"should instantiate the controller": (done)->
 			c = expect.sinon.spy!


### PR DESCRIPTION
An action with a special name (`root`? `default`?) or maybe using a decorator should become the handler for the root of the controller path. i.e. have `class Foo => bar: @root -> ...` generating both `GET /foo/bar` and `GET /foo` routes pointing to `@bar`.
